### PR TITLE
Added iproute2 to packaging

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ USER root
 # Install packages, download files ...
 ADD docker-* entrypoint healthcheck /sbin/
 ADD entrypoint.sh /usr/local/lib/
-RUN docker-apt apt-transport-https ca-certificates curl gettext pwgen wget vim
+RUN docker-apt apt-transport-https ca-certificates curl gettext pwgen wget vim iproute2
 
 # Configure: bash profile
 RUN sed --in-place --expression="/^HISTSIZE/s/1000/9999/" --expression="/^HISTFILESIZE/s/2000/99999/" /root/.bashrc && \


### PR DESCRIPTION
Alternative to adding to nginx image directly. iproute2 is swiss army knife of Linux networking packages. Makes sense to add it to base docker, which was essentially created for network applications